### PR TITLE
REF: Remove binomial_t from prng

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Experimental Core Pseudo Random Number Generator interface for future
 NumPy RandomState evolution.
 
 This is a library and generic interface for alternative random 
-generators in Python and NumPy. 
+generators in Python and NumPy.
+
+
+### Compatibility Warning
+Core PRNG no longer supports Box-Muller normal variates and so it not
+100% compatible with NumPy (or randomstate). Box-Muller normals are slow
+to generate and all functions which previously relied on Box-Muller
+normals now use the faster Ziggurat implementation.
 
 ## Features
 
@@ -42,14 +49,14 @@ y = rnd.standard_gamma(5.5, 10000, method='zig')
 
     * Uniforms (`random_sample`)
     * Exponentials (`standard_exponential`, both Inverse CDF and Ziggurat)
-    * Normals (`standard_normal`, both Box-Muller and Ziggurat)
-    * Standard Gammas (via `standard_gamma`, both Inverse CDF and Ziggurat)
+    * Normals (`standard_normal`)
+    * Standard Gammas (via `standard_gamma`)
   
   **WARNING**: The 32-bit generators are **experimental** and subject 
   to change.
   
   **Note**: There are _no_ plans to extend the alternative precision 
-  generation to all random number types.
+  generation to all distributions.
 
 * Support for filling existing arrays using `out` keyword argument. Currently
   supported in (both 32- and 64-bit outputs)
@@ -61,7 +68,7 @@ y = rnd.standard_gamma(5.5, 10000, method='zig')
 
 ## Included Pseudo Random Number Generators
 
-This modules includes a number of alternative random 
+This module includes a number of alternative random
 number generators in addition to the MT19937 that is included in NumPy. 
 The RNGs include:
 
@@ -71,23 +78,22 @@ The RNGs include:
   SSE2-aware version of the MT19937 generator that is especially fast at 
   generating doubles
 * [xoroshiro128+](http://xoroshiro.di.unimi.it/) and
-  [xorshift1024*](http://xorshift.di.unimi.it/)
+  [xorshift1024*φ](http://xorshift.di.unimi.it/)
 * [PCG64](http:w//www.pcg-random.org/)
-* ThreeFry and Philox implementationf from [Random123](https://www.deshawrsearch.com/resources_random123.html)
+* ThreeFry and Philox from [Random123](https://www.deshawrsearch.com/resources_random123.html)
 ## Differences from `numpy.random.RandomState`
 
 ### New Features
 * `standard_normal`, `normal`, `randn` and `multivariate_normal` all 
-  support an additional `method` keyword argument which can be `bm` or
-  `zig` where `bm` corresponds to the current method using the Box-Muller
-  transformation and `zig` uses the much faster (100%+) Ziggurat method.
-* `standard_exponential` and `standard_gamma` both support an additional
+  use the much faster (100%+) Ziggurat method.
+* `standard_gamma` and `gamma` both use the much faster Ziggurat method.
+* `standard_exponential` `exponential` both support an additional
   `method` keyword argument which can be `inv` or
   `zig` where `inv` corresponds to the current method using the inverse
   CDF and `zig` uses the much faster (100%+) Ziggurat method.
 * Core random number generators can produce either single precision
   (`np.float32`) or double precision (`np.float64`, the default) using
-  an the optional keyword argument `dtype`
+  the optional keyword argument `dtype`
 * Core random number generators can fill existing arrays using the
   `out` keyword argument
 
@@ -126,7 +132,7 @@ The version matched the latest version of NumPy where
 ## Documentation
 
 An occasionally updated build of the documentation is available on
-[my github pages](http://bashtage.github.io/core-prng/).
+[my GitHub pages](http://bashtage.github.io/core-prng/).
 
 ## Plans
 This module is essentially complete.  There are a few rough edges that 
@@ -139,8 +145,8 @@ need to be smoothed.
 Building requires:
 
   * Python (2.7, 3.4, 3.5, 3.6)
-  * NumPy (1.9, 1.10, 1.11, 1.12)
-  * Cython (0.22, **not** 0.23, 0.24, 0.25)
+  * NumPy (1.10, 1.11, 1.12, 1.13, 1.14)
+  * Cython (0.25+)
   * tempita (0.5+), if not provided by Cython
  
 Testing requires pytest (3.0+).
@@ -151,12 +157,12 @@ versions.
 ## Development and Testing
 
 All development has been on 64-bit Linux, and it is regularly tested on 
-Travis-CI (Linux) and Appveyor (Windows). The library is occasionally 
-tested on Linux 32-bit, OSX 10.13, Free BSD 11.1.
+Travis-CI (Linux/OSX) and Appveyor (Windows). The library is occasionally
+tested on Linux 32-bit and Free BSD 11.1.
 
 Basic tests are in place for all RNGs. The MT19937 is tested against 
 NumPy's implementation for identical results. It also passes NumPy's 
-test suite.
+test suite where still relevant.
 
 ## Installing
 
@@ -206,37 +212,37 @@ NumPy's mt19937.
 ```
 Speed-up relative to NumPy (Uniform Doubles)
 ************************************************************
-MT19937          22.9%
-PCG64           109.6%
-Philox           -6.2%
-ThreeFry        -16.6%
-Xoroshiro128    161.0%
-Xorshift1024    119.9%
+DSFMT           137.1%
+MT19937          21.0%
+PCG32           101.2%
+PCG64           110.7%
+Philox           -2.7%
+ThreeFry        -11.4%
+ThreeFry32      -62.3%
+Xoroshiro128    181.4%
+Xorshift1024    141.8%
 
 Speed-up relative to NumPy (64-bit unsigned integers)
 ************************************************************
-MT19937           6.2%
-PCG64            88.2%
-Philox          -23.0%
-ThreeFry        -26.5%
-Xoroshiro128    142.4%
-Xorshift1024    107.5%
+DSFMT            24.8%
+MT19937          15.0%
+PCG32            92.6%
+PCG64            99.0%
+Philox          -20.4%
+ThreeFry        -21.7%
+ThreeFry32      -64.4%
+Xoroshiro128    164.2%
+Xorshift1024    120.8%
 
-Speed-up relative to NumPy (Standard normals (Box-Muller))
+Speed-up relative to NumPy (Standard normals)
 ************************************************************
-MT19937          17.7%
-PCG64            35.6%
-Philox          -26.2%
-ThreeFry        -16.9%
-Xoroshiro128     57.9%
-Xorshift1024     40.9%
-
-Speed-up relative to NumPy (Standard normals (Ziggurat))
-************************************************************
-MT19937         107.9%
-PCG64           149.6%
-Philox           11.1%
-ThreeFry         78.8%
-Xoroshiro128    224.7%
-Xorshift1024    158.6%
+DSFMT           299.4%
+MT19937         271.2%
+PCG32           364.5%
+PCG64           364.2%
+Philox          256.9%
+ThreeFry        236.0%
+ThreeFry32       97.0%
+Xoroshiro128    477.4%
+Xorshift1024    360.7%
 ```

--- a/benchmark.py
+++ b/benchmark.py
@@ -103,16 +103,9 @@ def timer_64bit():
     run_timer(dist, command, command_numpy, SETUP, '64-bit unsigned integers')
 
 
-def timer_normal():
-    dist = 'standard_normal'
-    command = 'rg.standard_normal(1000000, method="bm")'
-    command_numpy = 'rg.standard_normal(1000000)'
-    run_timer(dist, command, command_numpy, SETUP, 'Box-Muller normals')
-
-
 def timer_normal_zig():
     dist = 'standard_normal'
-    command = 'rg.standard_normal(1000000, method="zig")'
+    command = 'rg.standard_normal(1000000)'
     command_numpy = 'rg.standard_normal(1000000)'
     run_timer(dist, command, command_numpy, SETUP,
               'Standard normals (Ziggurat)')
@@ -129,5 +122,4 @@ if __name__ == '__main__':
         timer_raw()
         timer_32bit()
         timer_64bit()
-        timer_normal()
         timer_normal_zig()

--- a/core_prng/common.pxd
+++ b/core_prng/common.pxd
@@ -21,6 +21,9 @@ cdef enum ConstraintType:
 
 ctypedef ConstraintType constraint_type
 
+cdef int check_constraint(double val, object name, constraint_type cons) except -1
+cdef int check_array_constraint(np.ndarray val, object name, constraint_type cons) except -1
+
 cdef extern from "src/aligned_malloc/aligned_malloc.h":
     cdef void *PyArray_realloc_aligned(void *p, size_t n);
     cdef void *PyArray_malloc_aligned(size_t n);

--- a/core_prng/distributions.pxd
+++ b/core_prng/distributions.pxd
@@ -32,7 +32,6 @@ cdef extern from "src/distributions/distributions.h":
         uint32_t (*next_uint32)(void *st) nogil
         double (*next_double)(void *st) nogil
         uint64_t (*next_raw)(void *st) nogil
-        binomial_t *binomial
 
     ctypedef prng prng_t
 
@@ -85,7 +84,7 @@ cdef extern from "src/distributions/distributions.h":
 
     long random_poisson(prng_t *prng_state, double lam) nogil
     long random_negative_binomial(prng_t *prng_state, double n, double p) nogil
-    long random_binomial(prng_t *prng_state, double p, long n) nogil
+    long random_binomial(prng_t *prng_state, double p, long n, binomial_t *binomial) nogil
     long random_logseries(prng_t *prng_state, double p) nogil
     long random_geometric_search(prng_t *prng_state, double p) nogil
     long random_geometric_inversion(prng_t *prng_state, double p) nogil

--- a/core_prng/dsfmt.pyx
+++ b/core_prng/dsfmt.pyx
@@ -6,7 +6,7 @@ import numpy as np
 cimport numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -88,7 +88,6 @@ cdef class DSFMT:
         self.rng_state.buffered_uniforms = <double *>PyArray_calloc_aligned(DSFMT_N64, sizeof(double))
         self.rng_state.buffer_loc = DSFMT_N64
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed)
         self._prng.state = <void *>self.rng_state
         self._prng.next_uint64 = &dsfmt_uint64
@@ -114,7 +113,6 @@ cdef class DSFMT:
         PyArray_free_aligned(self.rng_state.state)
         PyArray_free_aligned(self.rng_state.buffered_uniforms)
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):

--- a/core_prng/mt19937.pyx
+++ b/core_prng/mt19937.pyx
@@ -7,7 +7,7 @@ import numpy as np
 cimport numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 import core_prng.pickle
 from core_prng.entropy import random_entropy
 
@@ -61,7 +61,6 @@ cdef class MT19937:
     def __init__(self, seed=None):
         self.rng_state = <mt19937_state *>malloc(sizeof(mt19937_state))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed)
 
         self._prng.state = <void *>self.rng_state
@@ -75,7 +74,6 @@ cdef class MT19937:
 
     def __dealloc__(self):
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     # Pickling support:

--- a/core_prng/pcg32.pyx
+++ b/core_prng/pcg32.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -68,7 +68,6 @@ cdef class PCG32:
         self.rng_state = <pcg32_state *>malloc(sizeof(pcg32_state))
         self.rng_state.pcg_state = <pcg32_random_t *>malloc(sizeof(pcg32_random_t))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed, inc)
 
         self._prng.state = <void *>self.rng_state
@@ -94,7 +93,6 @@ cdef class PCG32:
 
     def __dealloc__(self):
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     def __random_integer(self, bits=64):

--- a/core_prng/pcg64.pyx
+++ b/core_prng/pcg64.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -83,7 +83,6 @@ cdef class PCG64:
         self.rng_state = <pcg64_state *>malloc(sizeof(pcg64_state))
         self.rng_state.pcg_state = <pcg64_random_t *>malloc(sizeof(pcg64_random_t))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed, inc)
 
         self._prng.state = <void *>self.rng_state
@@ -109,7 +108,6 @@ cdef class PCG64:
 
     def __dealloc__(self):
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):

--- a/core_prng/philox.pyx
+++ b/core_prng/philox.pyx
@@ -4,7 +4,7 @@ from cpython.pycapsule cimport PyCapsule_New
 import numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -76,7 +76,6 @@ cdef class Philox:
         self.rng_state.key = <philox4x64_key_t *> malloc(
             sizeof(philox4x64_key_t))
         self._prng = <prng_t *> malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *> malloc(sizeof(binomial_t))
         self.seed(seed, counter, key)
 
         self._prng.state = <void *> self.rng_state
@@ -104,7 +103,6 @@ cdef class Philox:
         free(self.rng_state.ctr)
         free(self.rng_state.key)
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):

--- a/core_prng/src/distributions/distributions.c
+++ b/core_prng/src/distributions/distributions.c
@@ -653,50 +653,50 @@ long random_negative_binomial(prng_t *prng_state, double n, double p) {
   return random_poisson(prng_state, Y);
 }
 
-long random_binomial_btpe(prng_t *prng_state, long n, double p) {
+long random_binomial_btpe(prng_t *prng_state, long n, double p, binomial_t* binomial) {
   double r, q, fm, p1, xm, xl, xr, c, laml, lamr, p2, p3, p4;
   double a, u, v, s, F, rho, t, A, nrq, x1, x2, f1, f2, z, z2, w, w2, x;
   long m, y, k, i;
 
-  if (!(prng_state->binomial->has_binomial) ||
-      (prng_state->binomial->nsave != n) ||
-      (prng_state->binomial->psave != p)) {
+  if (!(binomial->has_binomial) ||
+      (binomial->nsave != n) ||
+      (binomial->psave != p)) {
     /* initialize */
-    prng_state->binomial->nsave = n;
-    prng_state->binomial->psave = p;
-    prng_state->binomial->has_binomial = 1;
-    prng_state->binomial->r = r = min(p, 1.0 - p);
-    prng_state->binomial->q = q = 1.0 - r;
-    prng_state->binomial->fm = fm = n * r + r;
-    prng_state->binomial->m = m = (long)floor(prng_state->binomial->fm);
-    prng_state->binomial->p1 = p1 =
+    binomial->nsave = n;
+    binomial->psave = p;
+    binomial->has_binomial = 1;
+    binomial->r = r = min(p, 1.0 - p);
+    binomial->q = q = 1.0 - r;
+    binomial->fm = fm = n * r + r;
+    binomial->m = m = (long)floor(binomial->fm);
+    binomial->p1 = p1 =
         floor(2.195 * sqrt(n * r * q) - 4.6 * q) + 0.5;
-    prng_state->binomial->xm = xm = m + 0.5;
-    prng_state->binomial->xl = xl = xm - p1;
-    prng_state->binomial->xr = xr = xm + p1;
-    prng_state->binomial->c = c = 0.134 + 20.5 / (15.3 + m);
+    binomial->xm = xm = m + 0.5;
+    binomial->xl = xl = xm - p1;
+    binomial->xr = xr = xm + p1;
+    binomial->c = c = 0.134 + 20.5 / (15.3 + m);
     a = (fm - xl) / (fm - xl * r);
-    prng_state->binomial->laml = laml = a * (1.0 + a / 2.0);
+    binomial->laml = laml = a * (1.0 + a / 2.0);
     a = (xr - fm) / (xr * q);
-    prng_state->binomial->lamr = lamr = a * (1.0 + a / 2.0);
-    prng_state->binomial->p2 = p2 = p1 * (1.0 + 2.0 * c);
-    prng_state->binomial->p3 = p3 = p2 + c / laml;
-    prng_state->binomial->p4 = p4 = p3 + c / lamr;
+    binomial->lamr = lamr = a * (1.0 + a / 2.0);
+    binomial->p2 = p2 = p1 * (1.0 + 2.0 * c);
+    binomial->p3 = p3 = p2 + c / laml;
+    binomial->p4 = p4 = p3 + c / lamr;
   } else {
-    r = prng_state->binomial->r;
-    q = prng_state->binomial->q;
-    fm = prng_state->binomial->fm;
-    m = prng_state->binomial->m;
-    p1 = prng_state->binomial->p1;
-    xm = prng_state->binomial->xm;
-    xl = prng_state->binomial->xl;
-    xr = prng_state->binomial->xr;
-    c = prng_state->binomial->c;
-    laml = prng_state->binomial->laml;
-    lamr = prng_state->binomial->lamr;
-    p2 = prng_state->binomial->p2;
-    p3 = prng_state->binomial->p3;
-    p4 = prng_state->binomial->p4;
+    r = binomial->r;
+    q = binomial->q;
+    fm = binomial->fm;
+    m = binomial->m;
+    p1 = binomial->p1;
+    xm = binomial->xm;
+    xl = binomial->xl;
+    xr = binomial->xr;
+    c = binomial->c;
+    laml = binomial->laml;
+    lamr = binomial->lamr;
+    p2 = binomial->p2;
+    p3 = binomial->p3;
+    p4 = binomial->p4;
   }
 
 /* sigh ... */
@@ -794,26 +794,26 @@ Step60:
   return y;
 }
 
-long random_binomial_inversion(prng_t *prng_state, long n, double p) {
+long random_binomial_inversion(prng_t *prng_state, long n, double p, binomial_t* binomial) {
   double q, qn, np, px, U;
   long X, bound;
 
-  if (!(prng_state->binomial->has_binomial) ||
-      (prng_state->binomial->nsave != n) ||
-      (prng_state->binomial->psave != p)) {
-    prng_state->binomial->nsave = n;
-    prng_state->binomial->psave = p;
-    prng_state->binomial->has_binomial = 1;
-    prng_state->binomial->q = q = 1.0 - p;
-    prng_state->binomial->r = qn = exp(n * log(q));
-    prng_state->binomial->c = np = n * p;
-    prng_state->binomial->m = bound =
+  if (!(binomial->has_binomial) ||
+      (binomial->nsave != n) ||
+      (binomial->psave != p)) {
+    binomial->nsave = n;
+    binomial->psave = p;
+    binomial->has_binomial = 1;
+    binomial->q = q = 1.0 - p;
+    binomial->r = qn = exp(n * log(q));
+    binomial->c = np = n * p;
+    binomial->m = bound =
         (long)min(n, np + 10.0 * sqrt(np * q + 1));
   } else {
-    q = prng_state->binomial->q;
-    qn = prng_state->binomial->r;
-    np = prng_state->binomial->c;
-    bound = prng_state->binomial->m;
+    q = binomial->q;
+    qn = binomial->r;
+    np = binomial->c;
+    bound = binomial->m;
   }
   X = 0;
   px = qn;
@@ -832,21 +832,21 @@ long random_binomial_inversion(prng_t *prng_state, long n, double p) {
   return X;
 }
 
-long random_binomial(prng_t *prng_state, double p, long n) {
+long random_binomial(prng_t *prng_state, double p, long n, binomial_t * binomial) {
   double q;
 
   if (p <= 0.5) {
     if (p * n <= 30.0) {
-      return random_binomial_inversion(prng_state, n, p);
+      return random_binomial_inversion(prng_state, n, p, binomial);
     } else {
-      return random_binomial_btpe(prng_state, n, p);
+      return random_binomial_btpe(prng_state, n, p, binomial);
     }
   } else {
     q = 1.0 - p;
     if (q * n <= 30.0) {
-      return n - random_binomial_inversion(prng_state, n, q);
+      return n - random_binomial_inversion(prng_state, n, q, binomial);
     } else {
-      return n - random_binomial_btpe(prng_state, n, q);
+      return n - random_binomial_btpe(prng_state, n, q, binomial);
     }
   }
 }

--- a/core_prng/src/distributions/distributions.h
+++ b/core_prng/src/distributions/distributions.h
@@ -59,7 +59,6 @@ typedef struct prng {
   uint32_t (*next_uint32)(void *st);
   double (*next_double)(void *st);
   uint64_t (*next_raw)(void *st);
-  binomial_t *binomial;
 } prng_t;
 
 /* Inline generators for internal use */
@@ -140,7 +139,7 @@ DECLDIR double random_triangular(prng_t *prng_state, double left, double mode,
 
 DECLDIR long random_poisson(prng_t *prng_state, double lam);
 DECLDIR long random_negative_binomial(prng_t *prng_state, double n, double p);
-DECLDIR long random_binomial(prng_t *prng_state, double p, long n);
+DECLDIR long random_binomial(prng_t *prng_state, double p, long n, binomial_t* binomial);
 DECLDIR long random_logseries(prng_t *prng_state, double p);
 DECLDIR long random_geometric_search(prng_t *prng_state, double p);
 DECLDIR long random_geometric_inversion(prng_t *prng_state, double p);

--- a/core_prng/threefry.pyx
+++ b/core_prng/threefry.pyx
@@ -4,7 +4,7 @@ from cpython.pycapsule cimport PyCapsule_New
 import numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -70,7 +70,6 @@ cdef class ThreeFry:
         self.rng_state.ctr = <threefry4x64_ctr_t *>malloc(sizeof(threefry4x64_ctr_t))
         self.rng_state.key = <threefry4x64_key_t *>malloc(sizeof(threefry4x64_key_t))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed, counter, key)
 
         self._prng.state = <void *>self.rng_state
@@ -98,7 +97,6 @@ cdef class ThreeFry:
         free(self.rng_state.ctr)
         free(self.rng_state.key)
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):

--- a/core_prng/threefry32.pyx
+++ b/core_prng/threefry32.pyx
@@ -4,7 +4,7 @@ from cpython.pycapsule cimport PyCapsule_New
 import numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -73,7 +73,6 @@ cdef class ThreeFry32:
         self.rng_state.ctr = <threefry4x32_ctr_t *>malloc(sizeof(threefry4x32_ctr_t))
         self.rng_state.key = <threefry4x32_key_t *>malloc(sizeof(threefry4x32_key_t))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed, counter, key)
 
         self._prng.state = <void *>self.rng_state
@@ -101,7 +100,6 @@ cdef class ThreeFry32:
         free(self.rng_state.ctr)
         free(self.rng_state.key)
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):

--- a/core_prng/xorshift1024.pyx
+++ b/core_prng/xorshift1024.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 
 from common cimport *
-from distributions cimport prng_t, binomial_t
+from distributions cimport prng_t
 from core_prng.entropy import random_entropy
 import core_prng.pickle
 cimport entropy
@@ -56,7 +56,6 @@ cdef class Xorshift1024:
     def __init__(self, seed=None):
         self.rng_state = <xorshift1024_state *>malloc(sizeof(xorshift1024_state))
         self._prng = <prng_t *>malloc(sizeof(prng_t))
-        self._prng.binomial = <binomial_t *>malloc(sizeof(binomial_t))
         self.seed(seed)
 
         self._prng.state = <void *>self.rng_state
@@ -82,7 +81,6 @@ cdef class Xorshift1024:
 
     def __dealloc__(self):
         free(self.rng_state)
-        free(self._prng.binomial)
         free(self._prng)
 
     cdef _reset_state_variables(self):


### PR DESCRIPTION
Remove binomial_t from each prng_state and use a single implementation
at the level of a RandomGenerator